### PR TITLE
Allow instances of nested models as parameter types of orchestration …

### DIFF
--- a/lib/model_orchestration/base.rb
+++ b/lib/model_orchestration/base.rb
@@ -120,12 +120,12 @@ module ModelOrchestration
       @nested_model_instances = {}
     
       self._nested_models.each do |model|
-        klass = model.to_s.classify.constantize
+        model_class = model.to_s.classify.constantize
       
         if attrs.include?(model)
-          @nested_model_instances[model] = klass.new(attrs[model])
+          @nested_model_instances[model] = initialize_nested_model(model_class, attrs[model])
         else
-          @nested_model_instances[model] = klass.new
+          @nested_model_instances[model] = initialize_nested_model(model_class)
         end
       end
     
@@ -228,6 +228,16 @@ module ModelOrchestration
     
       def raise_validation_error
         raise(ValidationError.new(self))
+      end
+      
+      def initialize_nested_model(model_class, hash_or_instance = {})
+        if hash_or_instance.is_a? Hash
+          model_class.new(hash_or_instance)
+        elsif hash_or_instance.is_a? model_class
+          hash_or_instance
+        else
+          raise(TypeError, "hash_or_instance must be of type #{model_class.to_s}")
+        end
       end
   end
 end

--- a/test/examples/user_org_model_test.rb
+++ b/test/examples/user_org_model_test.rb
@@ -28,4 +28,17 @@ class UserOrgModelTest < Minitest::Test
     @user_org_model.org.name = nil
     assert !@user_org_model.valid?
   end
+  
+  def test_passing_nested_models_as_instances_to_orchestration_model
+    user = User.new(name: "Nils", age: 22)
+    org  = Org.new(name: "Nils' Webdesign Agency")
+    @user_org_model = UserOrgModel.new(user: user, org: org)
+    assert @user_org_model.valid?
+  end
+  
+  def test_only_hashes_or_correctly_typed_instances_may_be_passed_to_orchestration_model
+    assert_raises TypeError do
+      @user_org_model = UserOrgModel.new(user: "String instead of User class", org: "String instead of Org class")
+    end
+  end
 end


### PR DESCRIPTION
This should resolve issue #3. It allows to pass model instances to an orchestration model constructor instead of attribute hashes (which still work as expected).